### PR TITLE
Add MaplePath prototype with scraper and app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# project
+# MaplePath Prototype
+
+This repository contains a minimal prototype for the **MaplePath** immigration app.
+
+## Features
+
+* **Data Scraper** - `scraper/scrape_canada.py` fetches links from the official [canada.ca](https://www.canada.ca/en/services/immigration-citizenship.html) website and stores them in `data/immigration_links.json` with a timestamp.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the scraper:
+
+```bash
+python scraper/scrape_canada.py
+```
+
+The script prints how many links were saved and stores them in the `data` directory. Each output JSON includes the source URL and a `last_updated` timestamp.
+
+This is a starting point for syncing official immigration information into the MaplePath app.
+
+**Note:** The scraping script requires internet access. If running in a restricted environment, it may fail to fetch the official website. Run it locally with network access to update the data.

--- a/app/App.js
+++ b/app/App.js
@@ -1,0 +1,20 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Welcome to MaplePath!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,18 @@
+# MaplePath Mobile App
+
+This is a minimal React Native setup using Expo. It displays a single welcome screen.
+
+Install dependencies (requires Node and npm):
+
+```bash
+cd app
+npm install
+```
+
+Run the development server:
+
+```bash
+npx expo start
+```
+
+This launches the Expo dev tools where you can run the app on an emulator or device.

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "maplepath",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "expo": "~50.0.14",
+    "react": "18.2.0",
+    "react-native": "0.73.7"
+  }
+}

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+This directory stores scraped data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scraper/scrape_canada.py
+++ b/scraper/scrape_canada.py
@@ -1,0 +1,41 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://www.canada.ca/en/services/immigration-citizenship.html"
+
+
+def fetch_links():
+    response = requests.get(BASE_URL, timeout=15)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    links = []
+    # Example: collect navigation links from the page
+    for link in soup.select("a[href]"):
+        href = link.get("href")
+        text = link.get_text(strip=True)
+        if href and text:
+            if href.startswith("https://www.canada.ca") and len(text.split()) > 1:
+                links.append({"title": text, "url": href})
+    return links
+
+
+def main():
+    links = fetch_links()
+    out = {
+        "last_updated": datetime.utcnow().isoformat() + "Z",
+        "source": BASE_URL,
+        "links": links,
+    }
+    Path("data").mkdir(exist_ok=True)
+    outfile = Path("data/immigration_links.json")
+    outfile.write_text(json.dumps(out, indent=2, ensure_ascii=False))
+    print(f"Saved {len(links)} links to {outfile}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up MaplePath project README
- add Python scraper to fetch immigration links from canada.ca
- provide requirements.txt for scraper
- stub React Native app using Expo
- document usage of both components

## Testing
- `pip install -r requirements.txt`
- `python scraper/scrape_canada.py` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6844b3f2be1c832184f3991a39aa64ce